### PR TITLE
Remove preinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "next start",
     "lint": "next lint",
     "prettier": "prettier -w ./src",
-    "preinstall": "node preinstall.js"
   },
   "dependencies": {
     "next": "14.0.3",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removing the `preinstall` hook is low complexity, but the `scripts` block now has a trailing comma after `prettier`, making `package.json` invalid JSON and potentially breaking installs/builds.
> 
> **Overview**
> Removes the `preinstall` hook from `package.json` so installs no longer run `preinstall.js`.
> 
> Note: with `preinstall` removed, the `scripts` section now ends with a trailing comma after `prettier`, which makes `package.json` invalid JSON and can break `npm`/`yarn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 688459989902bf51763682d7813f11d207580c33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->